### PR TITLE
fixed openDirectory/walk functions limited to ~280 max path limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winapi-bindings",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Assorted winapi functions.",
   "main": "index.js",
   "repository": {

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -133,7 +133,13 @@ static const unsigned int BUFFER_SIZE = 1024;
 bool getFileDetails(const std::wstring &filePath, FILE_ALL_INFORMATION *fileInfo, size_t size) {
   DWORD flags = FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT;
 
-  HANDLE handle = CreateFileW(filePath.c_str(),
+  // Use extended-length path prefix to handle paths exceeding MAX_PATH (260 chars)
+  std::wstring longPath = filePath;
+  if (longPath.size() >= MAX_PATH && longPath.substr(0, 4) != L"\\\\?\\") {
+    longPath = L"\\\\?\\" + longPath;
+  }
+
+  HANDLE handle = CreateFileW(longPath.c_str(),
     FILE_READ_ATTRIBUTES,
     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
     nullptr,
@@ -150,7 +156,11 @@ bool getFileDetails(const std::wstring &filePath, FILE_ALL_INFORMATION *fileInfo
 }
 
 HANDLE openDirectory(const std::wstring &name) {
-  return ::CreateFileW(name.c_str()
+  std::wstring longName = name;
+  if (longName.size() >= MAX_PATH && longName.substr(0, 4) != L"\\\\?\\") {
+    longName = L"\\\\?\\" + longName;
+  }
+  return ::CreateFileW(longName.c_str()
     , GENERIC_READ
     , FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
     , nullptr

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -130,14 +130,23 @@ NtQueryInformationFile_type NtQueryInformationFile = nullptr;
 
 static const unsigned int BUFFER_SIZE = 1024;
 
+// Apply the Win32 extended-length path prefix (\\?\) for paths at or
+// exceeding MAX_PATH. This prefix disables Win32 path post-processing
+// so we must ensure the path is already well-formed: backslash-separated,
+// no relative components.
+std::wstring ensureLongPathPrefix(const std::wstring &path) {
+  if (path.size() < MAX_PATH || path.substr(0, 4) == L"\\\\?\\") {
+    return path;
+  }
+  std::wstring normalized = path;
+  std::replace(normalized.begin(), normalized.end(), L'/', L'\\');
+  return L"\\\\?\\" + normalized;
+}
+
 bool getFileDetails(const std::wstring &filePath, FILE_ALL_INFORMATION *fileInfo, size_t size) {
   DWORD flags = FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT;
 
-  // Use extended-length path prefix to handle paths exceeding MAX_PATH (260 chars)
-  std::wstring longPath = filePath;
-  if (longPath.size() >= MAX_PATH && longPath.substr(0, 4) != L"\\\\?\\") {
-    longPath = L"\\\\?\\" + longPath;
-  }
+  std::wstring longPath = ensureLongPathPrefix(filePath);
 
   HANDLE handle = CreateFileW(longPath.c_str(),
     FILE_READ_ATTRIBUTES,
@@ -156,10 +165,7 @@ bool getFileDetails(const std::wstring &filePath, FILE_ALL_INFORMATION *fileInfo
 }
 
 HANDLE openDirectory(const std::wstring &name) {
-  std::wstring longName = name;
-  if (longName.size() >= MAX_PATH && longName.substr(0, 4) != L"\\\\?\\") {
-    longName = L"\\\\?\\" + longName;
-  }
+  std::wstring longName = ensureLongPathPrefix(name);
   return ::CreateFileW(longName.c_str()
     , GENERIC_READ
     , FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE


### PR DESCRIPTION
Modern Electron/Node handle long paths automatically on Windows so our fs.ts module isn't affected - winapi-bindings/turbowalk on the other hand was not using long paths.

What this means is - when we walk the staging directory and generate hardlinks, CreateFileW would fail to provide us with the file's id causing it to get skipped on purge.

This gets compounded by yet another bug where we were losing precision of ids - JS number == 53 bits < fileId/inode info == 64 bits